### PR TITLE
Implement pagination for repository listing

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -95,14 +95,15 @@ func ListRepos(client *api.RESTClient, org string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		if len(response) == 0 {
+		numResults := len(response)
+		if numResults == 0 {
 			break
 		}
 		for _, repo := range response {
 			repos = append(repos, repo.Name)
 		}
 		// if less than perPage, no more pages
-		if len(response) < perPage {
+		if numResults < perPage {
 			break
 		}
 		page++

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/advanced-security/gh-ghas-audit
 
 go 1.23
-
 require (
 	github.com/cli/go-gh/v2 v2.11.2
 	github.com/fatih/color v1.18.0


### PR DESCRIPTION
Add pagination to the repository listing function to handle organizations with bigger number of repositories. 

This change improves the API calls for orgs with smaller number of repos as well as it increases the repositories per page pages (of 100).
