### PR TITLE
Add support for rate limiting

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -15,6 +15,8 @@ import (
 const (
 	// defaultRateLimitWaitSeconds is the fallback wait duration when no rate limit reset header is provided
 	defaultRateLimitWaitSeconds = 60
+	// rateLimitResetBuffer is added to the calculated wait duration to ensure the rate limit has reset
+	rateLimitResetBuffer = 1 * time.Second
 )
 
 // LANGUAGE_MAPPING normalizes different language names into a standard set.
@@ -214,7 +216,7 @@ func handleRateLimitFromError(httpErr *api.HTTPError) bool {
 			if resetUnix, err := strconv.ParseInt(resetHeader, 10, 64); err == nil {
 				resetAt := time.Unix(resetUnix, 0)
 				now := time.Now()
-				waitDuration := time.Until(resetAt) + (1 * time.Second) // Add 1s buffer
+				waitDuration := time.Until(resetAt) + rateLimitResetBuffer
 				fmt.Printf("Rate limit reset at: %s, Current time: %s, Wait duration: %.0f seconds\n",
 					resetAt.Format("15:04:05"), now.Format("15:04:05"), waitDuration.Seconds())
 				if waitDuration > 0 {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -12,6 +12,11 @@ import (
 	"github.com/cli/go-gh/v2/pkg/api"
 )
 
+const (
+	// defaultRateLimitWaitSeconds is the fallback wait duration when no rate limit reset header is provided
+	defaultRateLimitWaitSeconds = 60
+)
+
 // LANGUAGE_MAPPING normalizes different language names into a standard set.
 var LANGUAGE_MAPPING = map[string]string{
 	"actions":               "actions",
@@ -224,8 +229,8 @@ func handleRateLimitFromError(httpErr *api.HTTPError) bool {
 			}
 		}
 		// If no reset header, wait a default amount
-		fmt.Println("No X-RateLimit-Reset header found, waiting 60 seconds...")
-		time.Sleep(60 * time.Second)
+		fmt.Printf("No X-RateLimit-Reset header found, waiting %d seconds...\n", defaultRateLimitWaitSeconds)
+		time.Sleep(defaultRateLimitWaitSeconds * time.Second)
 		return true
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -86,14 +87,14 @@ func ListOrgs(client *api.RESTClient) ([]string, error) {
 
 // makeRequestWithRetry executes an API request with rate limit handling and retries.
 // Returns the response or an error after exhausting retries.
-func makeRequestWithRetry(client *api.RESTClient, method string, path string, body interface{}) (*http.Response, error) {
+func makeRequestWithRetry(client *api.RESTClient, method string, path string, body io.Reader) (*http.Response, error) {
 	maxRetries := 5
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if attempt > 0 {
 			fmt.Printf("Retry attempt %d/%d for request...\n", attempt, maxRetries)
 		}
-		resp, err := client.Request(method, path, nil)
+		resp, err := client.Request(method, path, body)
 
 		// Check if error is due to rate limiting
 		if err != nil {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cli/go-gh/v2/pkg/api"
 )
@@ -80,45 +84,184 @@ func ListOrgs(client *api.RESTClient) ([]string, error) {
 	return orgs, nil
 }
 
+// makeRequestWithRetry executes an API request with rate limit handling and retries.
+// Returns the response or an error after exhausting retries.
+func makeRequestWithRetry(client *api.RESTClient, method string, path string, body interface{}) (*http.Response, error) {
+	maxRetries := 5
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			fmt.Printf("Retry attempt %d/%d for request...\n", attempt, maxRetries)
+		}
+		resp, err := client.Request(method, path, nil)
+
+		// Check if error is due to rate limiting
+		if err != nil {
+			// Try to cast to HTTPError to check for rate limit
+			if httpErr, ok := err.(*api.HTTPError); ok {
+				if httpErr.StatusCode == 403 || httpErr.StatusCode == 429 {
+					// Handle rate limiting from error
+					if handleRateLimitFromError(httpErr) {
+						if attempt >= maxRetries {
+							return nil, fmt.Errorf("exceeded maximum retries due to rate limiting")
+						}
+						fmt.Printf("Rate limit handled, will retry (attempt %d/%d)\n", attempt+1, maxRetries)
+						continue
+					}
+				}
+			}
+			return nil, fmt.Errorf("request failed: %w", err)
+		}
+
+		// Success - return response for caller to handle
+		return resp, nil
+	}
+
+	return nil, fmt.Errorf("failed to get response after retries")
+}
+
 // listRepos returns a list of repository names under a given org.
 func ListRepos(client *api.RESTClient, org string) ([]string, error) {
 	perPage := 100
-	page := 1
 	var repos []string
+	path := fmt.Sprintf("orgs/%s/repos?per_page=%d", org, perPage)
 
-	for {
-		url := fmt.Sprintf("orgs/%s/repos?per_page=%d&page=%d", org, perPage, page)
-		var response []struct {
-			Name string
-		}
-		err := client.Get(url, &response)
+	for path != "" {
+		response, err := makeRequestWithRetry(client, "GET", path, nil)
 		if err != nil {
 			return nil, err
 		}
-		numResults := len(response)
-		if numResults == 0 {
-			break
+
+		if response.StatusCode != 200 {
+			response.Body.Close()
+			return nil, fmt.Errorf("unexpected status code: %d", response.StatusCode)
 		}
-		for _, repo := range response {
+
+		var repoList []struct {
+			Name string
+		}
+
+		// Decode response body
+		if err := json.NewDecoder(response.Body).Decode(&repoList); err != nil {
+			response.Body.Close()
+			return nil, err
+		}
+
+		for _, repo := range repoList {
 			repos = append(repos, repo.Name)
 		}
-		// if less than perPage, no more pages
-		if numResults < perPage {
-			break
+
+		// Check for next page in Link header before closing body
+		nextPath := ""
+		if linkHeader := response.Header.Get("Link"); linkHeader != "" {
+			nextPath = extractNextURL(linkHeader)
 		}
-		page++
+
+		// Close the response body before next iteration
+		response.Body.Close()
+
+		// Set path for next iteration
+		path = nextPath
 	}
 
 	return repos, nil
 }
 
+// extractNextURL parses the Link header and returns the URL for rel="next"
+func extractNextURL(linkHeader string) string {
+	// Link header format: <url>; rel="next", <url>; rel="last", etc.
+	links := strings.Split(linkHeader, ",")
+	for _, link := range links {
+		parts := strings.Split(strings.TrimSpace(link), ";")
+		if len(parts) < 2 {
+			continue
+		}
+		// Check if this is the "next" link
+		if strings.Contains(parts[1], `rel="next"`) {
+			// Extract URL from <url>
+			url := strings.TrimSpace(parts[0])
+			url = strings.TrimPrefix(url, "<")
+			url = strings.TrimSuffix(url, ">")
+			return url
+		}
+	}
+	return ""
+}
+
+// handleRateLimitFromError checks HTTPError for rate limiting and waits if necessary.
+// Returns true if the request should be retried, false otherwise.
+func handleRateLimitFromError(httpErr *api.HTTPError) bool {
+	if httpErr.StatusCode != 403 && httpErr.StatusCode != 429 {
+		return false
+	}
+
+	// Check if this is a rate limit error by looking for rate limit headers
+	remainingHeader := httpErr.Headers.Get("X-RateLimit-Remaining")
+	retryAfterHeader := httpErr.Headers.Get("Retry-After")
+	resetHeader := httpErr.Headers.Get("X-RateLimit-Reset")
+
+	// Primary rate limit: 403/429 with x-ratelimit-remaining: 0
+	if remainingHeader == "0" {
+		fmt.Printf("Primary rate limit exceeded. Status: %d, Remaining: %s\n",
+			httpErr.StatusCode, remainingHeader)
+		if resetHeader != "" {
+			if resetUnix, err := strconv.ParseInt(resetHeader, 10, 64); err == nil {
+				resetAt := time.Unix(resetUnix, 0)
+				now := time.Now()
+				waitDuration := time.Until(resetAt) + (1 * time.Second) // Add 1s buffer
+				fmt.Printf("Rate limit reset at: %s, Current time: %s, Wait duration: %.0f seconds\n",
+					resetAt.Format("15:04:05"), now.Format("15:04:05"), waitDuration.Seconds())
+				if waitDuration > 0 {
+					fmt.Printf("Waiting %.0f seconds...\n", waitDuration.Seconds())
+					time.Sleep(waitDuration)
+					fmt.Println("Wait complete, retrying request...")
+					return true
+				} else {
+					fmt.Println("Wait duration is negative or zero, rate limit should already be reset")
+					return true
+				}
+			}
+		}
+		// If no reset header, wait a default amount
+		fmt.Println("No X-RateLimit-Reset header found, waiting 60 seconds...")
+		time.Sleep(60 * time.Second)
+		return true
+	}
+
+	// Secondary rate limit: check for retry-after header
+	if retryAfterHeader != "" {
+		fmt.Printf("Secondary rate limit exceeded. Status: %d, Retry-After: %s seconds\n",
+			httpErr.StatusCode, retryAfterHeader)
+		if seconds, err := strconv.Atoi(retryAfterHeader); err == nil {
+			fmt.Printf("Waiting %d seconds...\n", seconds)
+			time.Sleep(time.Duration(seconds) * time.Second)
+			return true
+		}
+	}
+
+	// Not a rate limit error - it's a legitimate 403/429 for other reasons
+	return false
+}
+
 // getDefaultSetup fetches the default setup configuration for a repository.
 func GetDefaultSetup(client *api.RESTClient, org string, repo string) (DefaultSetupConfig, error) {
 	response := DefaultSetupConfig{}
-	err := client.Get(fmt.Sprintf("repos/%s/%s/code-scanning/default-setup", org, repo), &response)
+	path := fmt.Sprintf("repos/%s/%s/code-scanning/default-setup", org, repo)
+
+	resp, err := makeRequestWithRetry(client, "GET", path, nil)
 	if err != nil {
 		return response, err
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return response, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return response, fmt.Errorf("failed to decode response: %w", err)
+	}
+
 	return response, nil
 }
 
@@ -134,10 +277,22 @@ func (l LanguageCoverage) Languages() []string {
 // getLanguages fetches a repository's language breakdown.
 func GetLanguages(client *api.RESTClient, org string, repo string) (LanguageCoverage, error) {
 	response := make(LanguageCoverage)
-	err := client.Get(fmt.Sprintf("repos/%s/%s/languages", org, repo), &response)
+	path := fmt.Sprintf("repos/%s/%s/languages", org, repo)
+
+	resp, err := makeRequestWithRetry(client, "GET", path, nil)
 	if err != nil {
 		return response, err
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return response, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return response, fmt.Errorf("failed to decode response: %w", err)
+	}
+
 	return response, nil
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -89,7 +89,7 @@ func ListOrgs(client *api.RESTClient) ([]string, error) {
 func makeRequestWithRetry(client *api.RESTClient, method string, path string, body interface{}) (*http.Response, error) {
 	maxRetries := 5
 
-	for attempt := 0; attempt <= maxRetries; attempt++ {
+	for attempt := 0; attempt < maxRetries; attempt++ {
 		if attempt > 0 {
 			fmt.Printf("Retry attempt %d/%d for request...\n", attempt, maxRetries)
 		}


### PR DESCRIPTION
This pull request refactors the code scanning audit command to improve maintainability and robustness, especially around API request handling and rate limiting. The main changes include extracting repository processing logic into a reusable function, introducing a generic API request handler with automatic rate limit retries, and updating repository and language fetching to use this new handler. These improvements help ensure the tool is more resilient to GitHub API rate limits and simplify the main audit logic.


### API request handling and reliability improvements

* Added a new `makeRequestWithRetry` function in `cmd/utils.go` to handle API requests with automatic retries for rate limit errors, including support for primary and secondary rate limits using headers like `X-RateLimit-Reset` and `Retry-After`. Also added helper functions `extractNextURL` and `handleRateLimitFromError` for pagination and rate limit logic.
* Updated `GetDefaultSetup` and `GetLanguages` in `cmd/utils.go` to use the new `makeRequestWithRetry` function, improving error handling and decoding responses directly from the HTTP body.

### Refactoring and code simplification

* Introduced a new `processRepository` function in `cmd/code_scanning_audit.go` to encapsulate all logic for processing a repository and generating a report entry, reducing code duplication and centralizing error handling.
* Refactored `runCodeScanningAudit` in `cmd/code_scanning_audit.go` to use the new `processRepository` function for both single and multiple repository processing, replacing the previous inline logic and the `addReportEntry` helper. [[1]](diffhunk://#diff-1e93f0c8be4493d3cc1da8789287ce0e874b656140fda5ca9008ed58d97d030dL68-R111) [[2]](diffhunk://#diff-1e93f0c8be4493d3cc1da8789287ce0e874b656140fda5ca9008ed58d97d030dL124-R133)
* Removed the now-unnecessary `addReportEntry` helper function from `cmd/code_scanning_audit.go` as its logic is fully handled by `processRepository`.