### PR TITLE
Add command-line flags to exclude archived and forked repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Global Flags:
   -o, --organizations string   Comma separated list of organizations to audit
   -r, --repository string      Single repository to audit
       --skip-archived          Skip archived repositories
+      --skip-forks             Skip forked repositories
 ```
 
 ### Terminal Output

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Global Flags:
       --csv-output string      File path to output CSV report
   -o, --organizations string   Comma separated list of organizations to audit
   -r, --repository string      Single repository to audit
+      --skip-archived          Skip archived repositories
 ```
 
 ### Terminal Output

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ var (
 	Repository    string
 	CSVOutput     string // File path for CSV output
 	SkipArchived  bool   // Skip archived repositories
+	SkipForks     bool   // Skip forked repositories
 )
 
 // rootCmd is the base command called without any subcommands.
@@ -51,6 +52,12 @@ func init() {
 		"skip-archived",
 		false,
 		"Skip archived repositories",
+	)
+	rootCmd.PersistentFlags().BoolVar(
+		&SkipForks,
+		"skip-forks",
+		false,
+		"Skip forked repositories",
 	)
 
 	// Attach code-scanning subcommand.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ var (
 	Organizations string
 	Repository    string
 	CSVOutput     string // File path for CSV output
+	SkipArchived  bool   // Skip archived repositories
 )
 
 // rootCmd is the base command called without any subcommands.
@@ -44,6 +45,12 @@ func init() {
 		"csv-output",
 		"",
 		"File path to output CSV report",
+	)
+	rootCmd.PersistentFlags().BoolVar(
+		&SkipArchived,
+		"skip-archived",
+		false,
+		"Skip archived repositories",
 	)
 
 	// Attach code-scanning subcommand.

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -148,6 +148,7 @@ func ListRepos(client *api.RESTClient, org string) ([]string, error) {
 		var repoList []struct {
 			Name     string
 			Archived bool
+			Fork     bool
 		}
 
 		// Decode response body
@@ -158,6 +159,9 @@ func ListRepos(client *api.RESTClient, org string) ([]string, error) {
 
 		for _, repo := range repoList {
 			if SkipArchived && repo.Archived {
+				continue
+			}
+			if SkipForks && repo.Fork {
 				continue
 			}
 			repos = append(repos, repo.Name)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -146,7 +146,8 @@ func ListRepos(client *api.RESTClient, org string) ([]string, error) {
 		}
 
 		var repoList []struct {
-			Name string
+			Name     string
+			Archived bool
 		}
 
 		// Decode response body
@@ -156,6 +157,9 @@ func ListRepos(client *api.RESTClient, org string) ([]string, error) {
 		}
 
 		for _, repo := range repoList {
+			if SkipArchived && repo.Archived {
+				continue
+			}
 			repos = append(repos, repo.Name)
 		}
 


### PR DESCRIPTION
Add `--skip-archived` flag (to keep backward compatibility)

When flag is set archived repositories are not audited.

Add `--skip-forked` flag (to keep backward compatibility)

When flag is set forked repositories are not audited.

### CLI and flag updates
* Added `--skip-archived` and `--skip-forks` flags to the CLI, allowing users to exclude archived and forked repositories from audits. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R71-R72) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR50-R61)
* Updated the `README.md` to document the new flags for user reference.

### Internal filtering logic
* Extended the repository listing logic in `ListRepos` to filter out archived and forked repositories based on the new flags. [[1]](diffhunk://#diff-5b14f474a50427ede31c39509d3921643c7f757a8c680f3a8bdf8c072e1c2160R150-R151) [[2]](diffhunk://#diff-5b14f474a50427ede31c39509d3921643c7f757a8c680f3a8bdf8c072e1c2160R161-R166)
* Updated the repository struct to include `Archived` and `Fork` fields for filtering purposes.

### Configuration
* Added `SkipArchived` and `SkipForks` fields to the configuration struct for consistent flag handling throughout the codebase.