### PR TITLE
Implement incremental writing of CSV results

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ GHAS Audit helps you:
    - Default setup configuration using GitHub's [code scanning default setup API endpoints][default-setup-api].
 3. **Processing:** Each repository is processed to determine if code scanning is enabled, the list of normalized languages detected, and any languages not configured.
 4. **Reporting:** The results are compiled into a report:
-   - **Terminal Output:** Displays a formatted table.
-   - **CSV Output:** Exports results to a specified CSV file.
+   - **Terminal Output:** Displays a formatted table after all repositories are processed.
+   - **CSV Output:** Writes results incrementally to the specified CSV file as each repository is audited, ensuring partial results are saved even if the process is interrupted.
 
 ## Prerequisites
 
@@ -77,6 +77,8 @@ gh ghas-audit code-scanning -o my-org
 ```
 
 ### CSV Output
+
+Export results to a CSV file for further analysis or record-keeping. Results are written incrementally as each repository is processed, so if the audit is interrupted, partial results will still be available in the CSV file.
 
 ```bash
 gh ghas-audit code-scanning -o my-org --csv-output audit-report.csv


### PR DESCRIPTION
If the output is a CSV write results at the end of each repository audit.

If the audit fails with an error or the user aborts the process it will have partial results. It also allows progress monitoring by watching the file


Incremental CSV output and reliability improvements:
* Results are now written incrementally to the CSV file as each repository is audited, so partial results are preserved even if the process is interrupted (`cmd/code_scanning_audit.go`, `README.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R81-R82) [[3]](diffhunk://#diff-1e93f0c8be4493d3cc1da8789287ce0e874b656140fda5ca9008ed58d97d030dR121-R124) [[4]](diffhunk://#diff-1e93f0c8be4493d3cc1da8789287ce0e874b656140fda5ca9008ed58d97d030dR147-R151)

Reporting logic refactor:
* The `Printer` interface now includes a `PrintEntry` method for per-entry output, implemented by both `TerminalPrinter` and `CSVPrinter` (`cmd/report.go`). [[1]](diffhunk://#diff-ca6308f68e522f95358cc6bae5628b9bda6fc83f1668299662d9f0fd18e36253R30-R37) [[2]](diffhunk://#diff-ca6308f68e522f95358cc6bae5628b9bda6fc83f1668299662d9f0fd18e36253L86-R103)
* The terminal output buffers entries and displays the formatted table after all repositories are processed (`cmd/report.go`). [[1]](diffhunk://#diff-ca6308f68e522f95358cc6bae5628b9bda6fc83f1668299662d9f0fd18e36253R64-R90) [[2]](diffhunk://#diff-ca6308f68e522f95358cc6bae5628b9bda6fc83f1668299662d9f0fd18e36253L123-R146)
* The CSV output writes each entry immediately and flushes the writer to disk, with proper file closing on exit (`cmd/report.go`, `cmd/code_scanning_audit.go`). [[1]](diffhunk://#diff-ca6308f68e522f95358cc6bae5628b9bda6fc83f1668299662d9f0fd18e36253R115-R120) [[2]](diffhunk://#diff-1e93f0c8be4493d3cc1da8789287ce0e874b656140fda5ca9008ed58d97d030dR95-R103)

Documentation updates:
* The `README.md` is updated to clarify the incremental CSV output behavior and its benefits for reliability (`README.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R23) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R81-R82)