### PR TITLE
Audit Repositories by Security Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ Flags:
   -h, --help   help for code-scanning
 
 Global Flags:
-      --csv-output string      File path to output CSV report
-  -o, --organizations string   Comma separated list of organizations to audit
-  -r, --repository string      Single repository to audit
+      --csv-output string               File path to output CSV report
+  -o, --organizations string            Comma separated list of organizations to audit
+  -r, --repository string               Single repository to audit
+      --security-configuration string   Filter repositories by security configuration name
 ```
 
 ### Terminal Output
@@ -81,6 +82,20 @@ gh ghas-audit code-scanning -o my-org
 ```bash
 gh ghas-audit code-scanning -o my-org --csv-output audit-report.csv
 ```
+
+### Filter by Security Configuration
+
+You can filter the audit to only include repositories that have a specific security configuration attached:
+
+```bash
+# Using configuration name
+gh ghas-audit code-scanning -o my-org --security-configuration "Production Config"
+```
+
+This is useful when you want to:
+- Audit only repositories with specific security policies
+- Verify compliance for a subset of repositories
+- Generate reports for different security tiers
 
 ### Example Usages
 

--- a/cmd/code_scanning_audit.go
+++ b/cmd/code_scanning_audit.go
@@ -121,7 +121,7 @@ func runCodeScanningAudit(c *cobra.Command, args []string) {
 		for _, org := range orgs {
 			org = strings.TrimSpace(org)
 			fmt.Println("Processing organization:", org)
-			repos, err := ListRepos(client, org)
+			repos, err := ListRepos(client, org, SecurityConfiguration)
 			if err != nil {
 				fmt.Println("Error listing repos for", org+":", err)
 				return

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,9 +9,10 @@ import (
 
 // Holds flags for organizations and repository.
 var (
-	Organizations string
-	Repository    string
-	CSVOutput     string // File path for CSV output
+	Organizations         string
+	Repository            string
+	CSVOutput             string // File path for CSV output
+	SecurityConfiguration string // Security configuration name to filter repos
 )
 
 // rootCmd is the base command called without any subcommands.
@@ -45,8 +46,7 @@ func init() {
 		"",
 		"File path to output CSV report",
 	)
-
-	// Attach code-scanning subcommand.
+	rootCmd.PersistentFlags().StringVar(&SecurityConfiguration, "security-configuration", "", "Filter repositories by security configuration name")
 	rootCmd.AddCommand(codeScanningAuditCmd)
 }
 


### PR DESCRIPTION
When a security configuration is passed (optional) audit only the repositories that are attached to the specified security configuration


**Feature: Security Configuration Filtering**
* Added a new `--security-configuration` flag to the CLI, enabling users to filter repositories by a specific security configuration name. (`cmd/root.go` [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL48-R49) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR15)
* Updated the audit logic to use the new filter: the `ListRepos` function now takes an optional security configuration and returns only repositories attached to the specified configuration. (`cmd/code_scanning_audit.go` [[1]](diffhunk://#diff-1e93f0c8be4493d3cc1da8789287ce0e874b656140fda5ca9008ed58d97d030dL124-R124) `cmd/utils.go` [[2]](diffhunk://#diff-5b14f474a50427ede31c39509d3921643c7f757a8c680f3a8bdf8c072e1c2160R131-R245)

**Documentation Updates**
* Updated `README.md` to document the new flag and provide usage examples for filtering by security configuration, including practical scenarios for compliance and tiered reporting. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R71) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R86-R99)

**Implementation Details**
* Added helper functions to find a security configuration by name and list repositories attached to it, including pagination support for large organizations. (`cmd/utils.go` [cmd/utils.goR131-R245](diffhunk://#diff-5b14f474a50427ede31c39509d3921643c7f757a8c680f3a8bdf8c072e1c2160R131-R245))